### PR TITLE
chore: add minimal permissions to reusable workflow files

### DIFF
--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -3,6 +3,9 @@ name: PR Gate
 on:
   pull_request:
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/reusable-backend-ci.yml
+++ b/.github/workflows/reusable-backend-ci.yml
@@ -4,6 +4,9 @@ on:
   workflow_call:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 defaults:
   run:
     working-directory: backend

--- a/.github/workflows/reusable-frontend-ci.yml
+++ b/.github/workflows/reusable-frontend-ci.yml
@@ -4,6 +4,9 @@ on:
   workflow_call:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 defaults:
   run:
     working-directory: frontend


### PR DESCRIPTION
To minimize the scopes granted, added `contents: read` to the reusable frontend/backend workflows and the PR gate workflow.

Closes #69