### PR TITLE
ci: add auto-assign feature to PR workflow

### DIFF
--- a/.github/workflows/pr-automation.yml
+++ b/.github/workflows/pr-automation.yml
@@ -1,4 +1,4 @@
-name: PR body updater
+name: PR Automation
 
 on:
   pull_request:

--- a/.github/workflows/pr-automation.yml
+++ b/.github/workflows/pr-automation.yml
@@ -68,11 +68,11 @@ jobs:
           GH_REPO: ${{ github.repository }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
-          ASSIGNEE_COUNT=$(gh pr view $PR_NUMBER --json assignees --jq '(.assignees | length)')
+          ASSIGNEE_COUNT=$(gh pr view "$PR_NUMBER" --json assignees --jq '(.assignees | length)')
 
           if [ "$ASSIGNEE_COUNT" -eq 0 ]; then
             echo "No assignees found. Assigning the author: ${{ github.actor }}"
-            gh pr edit $PR_NUMBER --add-assignee ${{ github.actor }}
+            gh pr edit "$PR_NUMBER" --add-assignee "${{ github.actor }}"
           else
             echo "This PR already has $ASSIGNEE_COUNT assignee(s). Skipping."
           fi

--- a/.github/workflows/pr-automation.yml
+++ b/.github/workflows/pr-automation.yml
@@ -54,3 +54,25 @@ jobs:
 
           echo "Updating PR #${PR_NUMBER} body."
           gh pr edit "$PR_NUMBER" --body "$UPDATED_BODY"
+
+  auto-assignment:
+    if: >-
+      github.event.action == 'opened' &&
+      endsWith(github.actor, '[bot]') == false
+    timeout-minutes: 3
+    runs-on: ubuntu-latest
+    steps:
+      - name: Add event actor to assignees
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          ASSIGNEE_COUNT=$(gh pr view $PR_NUMBER --json assignees --jq '(.assignees | length)')
+
+          if [ "$ASSIGNEE_COUNT" -eq 0 ]; then
+            echo "No assignees found. Assigning the author: ${{ github.actor }}"
+            gh pr edit $PR_NUMBER --add-assignee ${{ github.actor }}
+          else
+            echo "This PR already has $ASSIGNEE_COUNT assignee(s). Skipping."
+          fi


### PR DESCRIPTION
Assignee選択の手間を減らすために、Assigneesが未割り当てならPRを開いた人を自動追加する機能を追加。

Closes #95