### PR TITLE
Feature/99 setup neoshowcase

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,0 +1,17 @@
+# Backend local development example env
+# Copy to .env (optional) and adjust if needed
+# docker compose は .env が存在すれば読み込まれます。無くても environment のデフォルトで起動します。
+
+# App server address (for local development)
+APP_ADDR=:8080
+
+# DB connection - NeoShowcaseと同じ環境変数名を使用
+# PaaS環境では以下が自動で提供されます
+NS_MARIADB_USER=root
+NS_MARIADB_PASSWORD=pass
+NS_MARIADB_HOSTNAME=db
+NS_MARIADB_PORT=3306
+NS_MARIADB_DATABASE=app
+
+# Optional: override network (advanced)
+# DB_NET=tcp

--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -1,4 +1,5 @@
 /.env
+.env.local
 /tmp/
 /bin/
 

--- a/backend/compose.yml
+++ b/backend/compose.yml
@@ -23,18 +23,18 @@ services:
           path: ./
 
   db:
-    image: mysql:latest
-    command: mysqld --character-set-server=utf8mb4 --collation-server=utf8mb4_unicode_ci
+    image: mariadb:latest
+    command: mariadbd --character-set-server=utf8mb4 --collation-server=utf8mb4_unicode_ci
     environment:
       MYSQL_ROOT_PASSWORD: pass
       MYSQL_DATABASE: app
     expose:
       - "3306"
     healthcheck:
-      test: mysql --user=root --password=pass --execute "SHOW DATABASES;"
-      interval: 1s
-      timeout: 10s
-      retries: 30
+      test: ["CMD", "mariadb", "-u", "root", "-ppass", "-e", "SELECT 1"]
+      interval: 5s
+      timeout: 3s
+      retries: 5
 
   adminer:
     image: adminer:latest

--- a/backend/compose.yml
+++ b/backend/compose.yml
@@ -8,12 +8,11 @@ services:
     ports:
       - "8080:8080"
     environment:
-      APP_ADDR: :8080
-      DB_USER: root
-      DB_PASS: pass
-      DB_HOST: db
-      DB_PORT: "3306"
-      DB_NAME: app
+      NS_MARIADB_USER: ${NS_MARIADB_USER:-root}
+      NS_MARIADB_PASSWORD: ${NS_MARIADB_PASSWORD:-pass}
+      NS_MARIADB_HOSTNAME: ${NS_MARIADB_HOSTNAME:-db}
+      NS_MARIADB_PORT: ${NS_MARIADB_PORT:-3306}
+      NS_MARIADB_DATABASE: ${NS_MARIADB_DATABASE:-app}
     depends_on:
       db:
         condition: service_healthy
@@ -23,18 +22,18 @@ services:
           path: ./
 
   db:
-    image: mariadb:latest
-    command: mariadbd --character-set-server=utf8mb4 --collation-server=utf8mb4_unicode_ci
+    image: mariadb:10.11
+    command: mysqld --character-set-server=utf8mb4 --collation-server=utf8mb4_unicode_ci
     environment:
-      MYSQL_ROOT_PASSWORD: pass
-      MYSQL_DATABASE: app
+      MARIADB_ROOT_PASSWORD: pass
+      MARIADB_DATABASE: app
     expose:
       - "3306"
     healthcheck:
-      test: ["CMD", "mariadb", "-u", "root", "-ppass", "-e", "SELECT 1"]
-      interval: 5s
-      timeout: 3s
-      retries: 5
+      test: mysql --user=root --password=pass --execute "SHOW DATABASES;"
+      interval: 1s
+      timeout: 10s
+      retries: 30
 
   adminer:
     image: adminer:latest

--- a/backend/pkg/config/config.go
+++ b/backend/pkg/config/config.go
@@ -16,22 +16,42 @@ func getEnv(key, defaultValue string) string {
 	return v
 }
 
+// getEnvAny returns the first set environment value among keys, or defaultValue.
+func getEnvAny(defaultValue string, keys ...string) string {
+	for _, k := range keys {
+		if v, ok := os.LookupEnv(k); ok {
+			return v
+		}
+	}
+
+	return defaultValue
+}
+
 func AppAddr() string {
-	return getEnv("APP_ADDR", ":8080")
+	// Prefer explicit APP_ADDR (e.g., ":8080").
+	// Fallback to PORT (common on PaaS like NeoShowcase/Heroku) if provided.
+	if v, ok := os.LookupEnv("APP_ADDR"); ok && v != "" {
+		return v
+	}
+	if p, ok := os.LookupEnv("PORT"); ok && p != "" {
+		return ":" + p
+	}
+	return ":8080"
 }
 
 func MySQL() *mysql.Config {
 	c := mysql.NewConfig()
 
-	c.User = getEnv("DB_USER", "root")
-	c.Passwd = getEnv("DB_PASS", "pass")
+	// Prefer NS_MARIADB_* (PaaS-provided) first, then DB_* as fallback.
+	c.User = getEnvAny("root", "NS_MARIADB_USER", "DB_USER")
+	c.Passwd = getEnvAny("pass", "NS_MARIADB_PASSWORD", "DB_PASS")
 	c.Net = getEnv("DB_NET", "tcp")
 	c.Addr = fmt.Sprintf(
 		"%s:%s",
-		getEnv("DB_HOST", "localhost"),
-		getEnv("DB_PORT", "3306"),
+		getEnvAny("localhost", "NS_MARIADB_HOSTNAME", "DB_HOST"),
+		getEnvAny("3306", "NS_MARIADB_PORT", "DB_PORT"),
 	)
-	c.DBName = getEnv("DB_NAME", "app")
+	c.DBName = getEnvAny("app", "NS_MARIADB_DATABASE", "DB_NAME")
 	c.Collation = "utf8mb4_general_ci"
 	c.AllowNativePasswords = true
 	c.ParseTime = true // DATETIME型をtime.Timeに変換

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -6,13 +6,19 @@ import vueDevTools from 'vite-plugin-vue-devtools'
 
 // https://vite.dev/config/
 export default defineConfig({
-  plugins: [
-    vue(),
-    vueDevTools(),
-  ],
+  plugins: [vue(), vueDevTools()],
   resolve: {
     alias: {
-      '@': fileURLToPath(new URL('./src', import.meta.url))
+      '@': fileURLToPath(new URL('./src', import.meta.url)),
+    },
+  },
+  // 開発時のみ有効
+  server: {
+    proxy: {
+      '/api': {
+        target: 'http://localhost:8080',
+        changeOrigin: true,
+      },
     },
   },
 })


### PR DESCRIPTION
## NeoShowcaseの開発サーバー作った

何とかNeoShowcase対応できました。
今は、`1m25-10-dev`のみで、`feature/99-setup-neoshowcase`ブランチについて行ってます。

つど、監視するブランチは手動で変更するつもりです。
(developブランチ作ろうか考えたけど、時間なさすぎるのでこんな感じで手動変更で対応しようかな。いい方法あったら教えてください。)

### 確認URL

- frontend-dev: https://1m25-10-dev.trap.show
- backend-dev: https://1m25-10-dev.trap.show/api
  - ping(チェック用): https://1m25-10-dev.trap.show/api/v1/ping

### その他

まだ、変更加えるかもなので、一旦Draftです。


ref: #99