### PR TITLE
feat: add endpoint to get oldest post detail by image uuid

### DIFF
--- a/backend/internal/handler/handler.go
+++ b/backend/internal/handler/handler.go
@@ -46,6 +46,7 @@ func (h *Handler) SetupAppRoutes(api *echo.Group) {
 	imagesAPI := api.Group("/images")
 	{
 		imagesAPI.GET("", h.GetTraqMessagesSearchImages)
+		imagesAPI.GET("/:id", h.GetLatestMessageByImageID)
 	}
 
 }

--- a/backend/internal/handler/traq_messages.go
+++ b/backend/internal/handler/traq_messages.go
@@ -287,3 +287,43 @@ func (h *Handler) GetTraqMessagesSearch(c echo.Context) error {
 	body, status, _ := h.searchTraqMessages(c, params)
 	return c.Blob(status, "application/json", body)
 }
+
+// GetLatestMessageByImageID
+// GET /api/v1/images/:id
+// 指定されたファイルUUIDを含む https://q.trap.jp/files/<uuid> を語句検索し、
+// createdAt 昇順（古い順）に並べて最古の1件のヒットのみを返します。
+func (h *Handler) GetLatestMessageByImageID(c echo.Context) error {
+	id := c.Param("id")
+	if id == "" {
+		return echo.NewHTTPError(http.StatusBadRequest, "id is required")
+	}
+
+	word := "https://q.trap.jp/files/" + id
+	limit := 1
+	// 最古を取得するため昇順
+	sort := "createdAt"
+	params := &traqMessageSearchParams{
+		Word:  word,
+		Limit: &limit,
+		Sort:  sort,
+	}
+
+	body, status, err := h.searchTraqMessages(c, params)
+	if err != nil {
+		// traQ 側のエラーはそのまま中継
+		return c.Blob(status, "application/json", body)
+	}
+
+	// レスポンスから最古1件のhitのみ抽出（昇順ソートの先頭）
+	var resp struct {
+		Hits []json.RawMessage `json:"hits"`
+	}
+	if uerr := json.Unmarshal(body, &resp); uerr != nil {
+		return echo.NewHTTPError(http.StatusInternalServerError, "failed to parse traQ response").SetInternal(uerr)
+	}
+	if len(resp.Hits) == 0 {
+		return echo.NewHTTPError(http.StatusNotFound, "no message found for the given image id")
+	}
+	// 先頭(最古)のみ返す
+	return c.Blob(http.StatusOK, "application/json", resp.Hits[0])
+}

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -58,6 +58,11 @@ const routes = [
     component: () => import('@/views/TraqMessageSearchTestView.vue'),
   },
   {
+    path: '/test/image-detail',
+    name: 'imagePostDetailTest',
+    component: () => import('@/views/ImageDetailTest.vue'),
+  },
+  {
     path: '/test/oauth-debug',
     name: 'oauthDebugTest',
     component: () => import('@/views/OAuthDebugTestView.vue'),

--- a/frontend/src/views/ImageDetailTest.vue
+++ b/frontend/src/views/ImageDetailTest.vue
@@ -1,0 +1,165 @@
+<template>
+  <div class="image-detail-test">
+    <div class="container">
+      <h1>Image Post Detail Test</h1>
+
+      <div class="test-section">
+        <h2>Authentication Status</h2>
+        <p v-if="isLoggedIn" class="status-logged-in">
+          ✅ Logged in as: {{ userInfo?.name || 'Unknown' }}
+        </p>
+        <p v-else class="status-not-logged-in">
+          ❌ Not logged in. Please <router-link to="/account">login</router-link> first.
+        </p>
+      </div>
+
+      <div v-if="isLoggedIn" class="test-section">
+        <h2>Get Post Detail by File UUID</h2>
+        <p>
+          <code>GET /api/v1/images/{uuid}</code> により、
+          <code>https://q.trap.jp/files/{uuid}</code> を語句検索して、
+          投稿者・本文・スタンプなどを含む投稿詳細（最も古い1件）を返します。
+        </p>
+
+        <div class="input-section">
+          <input v-model="uuid" type="text" placeholder="Enter image/file UUID" class="uuid-input" />
+          <button @click="run" :disabled="!uuid || loading" class="test-button">Run</button>
+          <button @click="setTemplate" :disabled="loading" class="test-button">Use Template</button>
+        </div>
+
+        <div class="result-section">
+          <h3>Post Detail (Oldest)</h3>
+          <div v-if="loading">Loading...</div>
+          <div v-else-if="error" class="error">Error: {{ error }}</div>
+          <pre v-else class="json">{{ prettyJson }}</pre>
+        </div>
+      </div>
+
+      <div class="test-section">
+        <h2>API Endpoint</h2>
+        <div class="endpoint-info">
+          <ul>
+            <li>
+              <code>GET /api/v1/images/{uuid}</code> - ファイルUUIDから投稿詳細（最も古い1件）を返す
+            </li>
+          </ul>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, computed, onMounted } from 'vue'
+import { useUserStore } from '@/stores/userStore'
+
+const userStore = useUserStore()
+
+const TEMPLATE_UUID = '01991edf-51bb-72ac-b380-a607a9d2b474'
+const uuid = ref(TEMPLATE_UUID)
+const loading = ref(false)
+const error = ref<string | null>(null)
+const result = ref<unknown>(null)
+
+const isLoggedIn = computed(() => userStore.me !== null)
+const userInfo = computed(() => userStore.me)
+const prettyJson = computed(() => JSON.stringify(result.value, null, 2))
+
+function setTemplate() {
+  uuid.value = TEMPLATE_UUID
+}
+
+async function run() {
+  loading.value = true
+  error.value = null
+  result.value = null
+  try {
+    const res = await fetch(`/api/v1/images/${encodeURIComponent(uuid.value)}`, {
+      credentials: 'same-origin',
+    })
+    if (!res.ok) {
+      const t = await res.text()
+      throw new Error(t || `HTTP ${res.status}`)
+    }
+    result.value = await res.json()
+  } catch (e: unknown) {
+    error.value = e instanceof Error ? e.message : String(e)
+  } finally {
+    loading.value = false
+  }
+}
+
+onMounted(async () => {
+  if (userStore.me === null) {
+    await userStore.fetchMe()
+  }
+})
+</script>
+
+<style scoped>
+.image-detail-test {
+  min-height: 100vh;
+  background: #f8f9fa;
+  padding: 20px;
+}
+.container {
+  max-width: 1200px;
+  margin: 0 auto;
+}
+h1 {
+  text-align: center;
+  color: #333;
+  margin-bottom: 40px;
+  font-size: 32px;
+}
+.test-section {
+  margin-bottom: 50px;
+}
+.test-section h2 {
+  color: #555;
+  margin-bottom: 20px;
+  font-size: 24px;
+  border-bottom: 2px solid #007bff;
+  padding-bottom: 10px;
+}
+.input-section {
+  display: flex;
+  gap: 8px;
+  margin: 8px 0;
+}
+.uuid-input {
+  flex: 1;
+  padding: 8px;
+  border: 1px solid #ddd;
+  border-radius: 4px;
+}
+.test-button,
+.copy-button {
+  padding: 8px 12px;
+  background: #007bff;
+  color: white;
+  border: none;
+  border-radius: 4px;
+}
+.json {
+  background: #fff;
+  padding: 12px;
+  border-radius: 6px;
+  overflow: auto;
+}
+.error {
+  color: #b00020;
+}
+.sample-list {
+  padding: 0;
+  list-style: none;
+}
+.sample-list li {
+  padding: 6px 0;
+}
+@media (max-width: 768px) {
+  .container {
+    padding: 0 10px;
+  }
+}
+</style>

--- a/frontend/src/views/ImageDetailTest.vue
+++ b/frontend/src/views/ImageDetailTest.vue
@@ -22,7 +22,12 @@
         </p>
 
         <div class="input-section">
-          <input v-model="uuid" type="text" placeholder="Enter image/file UUID" class="uuid-input" />
+          <input
+            v-model="uuid"
+            type="text"
+            placeholder="Enter image/file UUID"
+            class="uuid-input"
+          />
           <button @click="run" :disabled="!uuid || loading" class="test-button">Run</button>
           <button @click="setTemplate" :disabled="loading" class="test-button">Use Template</button>
         </div>

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -251,13 +251,15 @@ paths:
         '500':
           $ref: '#/components/responses/ServerError'
 
-  /images/{id}:
+  /api/v1/images/{id}:
     get:
-      summary: IDで画像詳細を取得
-      description: 特定の画像の作成者と投稿データを含む詳細情報を返します
-      operationId: getImageDetail
+      summary: ファイルUUIDから投稿詳細を取得
+      description: '指定されたファイル/画像UUIDに対応するURL (https://q.trap.jp/files/{id}) を語句検索し、古い順で最も古い1件の投稿（作成者、本文、スタンプ等を含む）を返します。返却はtraQメッセージ検索のヒットオブジェクトをそのまま返します。'
+      operationId: getLatestMessageByImageId
       tags:
         - Images
+      security:
+        - CookieAuth: []
       parameters:
         - name: id
           in: path
@@ -269,15 +271,46 @@ paths:
           example: "550e8400-e29b-41d4-a716-446655440001"
       responses:
         '200':
-          description: 成功レスポンス
+          description: 最も古いヒット1件
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ImageDetail'
+                type: object
+                additionalProperties: true
+        '401':
+          $ref: '#/components/responses/Unauthorized'
         '404':
           $ref: '#/components/responses/NotFound'
         '500':
           $ref: '#/components/responses/ServerError'
+
+  # /images/{id}:
+  #   get:
+  #     summary: IDで画像詳細を取得
+  #     description: 特定の画像の作成者と投稿データを含む詳細情報を返します
+  #     operationId: getImageDetail
+  #     tags:
+  #       - Images
+  #     parameters:
+  #       - name: id
+  #         in: path
+  #         required: true
+  #         description: 画像のUUID
+  #         schema:
+  #           type: string
+  #           format: uuid
+  #         example: "550e8400-e29b-41d4-a716-446655440001"
+  #     responses:
+  #       '200':
+  #         description: 成功レスポンス
+  #         content:
+  #           application/json:
+  #             schema:
+  #               $ref: '#/components/schemas/ImageDetail'
+  #       '404':
+  #         $ref: '#/components/responses/NotFound'
+  #       '500':
+  #         $ref: '#/components/responses/ServerError'
 
   /albums:
     get:


### PR DESCRIPTION
`api/v1/images/{id}`で画像の投稿情報を取れます。
内部で、検索を回して一番初めに引っかかった投稿情報です。

投稿者のid(not username)や、投稿時のcontents、スタンプ等が取れます。

Closes #35