### PR TITLE
Potential fix for code scanning alert no. 7: Bad redirect check

### DIFF
--- a/backend/internal/handler/auth.go
+++ b/backend/internal/handler/auth.go
@@ -101,7 +101,10 @@ func (h *Handler) AuthCallback(c echo.Context) error {
 
 	// callbackへリダイレクト
 	cb := "/"
-	if cbCookie, err := c.Cookie(cookieCallbackKey); err == nil && cbCookie.Value != "" && strings.HasPrefix(cbCookie.Value, "/") {
+	if cbCookie, err := c.Cookie(cookieCallbackKey); err == nil &&
+		cbCookie.Value != "" &&
+		cbCookie.Value[0] == '/' &&
+		(len(cbCookie.Value) == 1 || (cbCookie.Value[1] != '/' && cbCookie.Value[1] != '\\')) {
 		cb = cbCookie.Value
 	}
 	delCookie(c, cookieCallbackKey)


### PR DESCRIPTION
Potential fix for [https://github.com/traP-jp/1m25_10/security/code-scanning/7](https://github.com/traP-jp/1m25_10/security/code-scanning/7)

To ensure the redirect location cannot be used to perform an open redirect, the check must not only verify that the value starts with a single slash, but also ensure the second character is *not* a slash (`/`) or a backslash (`\`). This can be achieved by extending the condition to check the length and the characters at index 1 appropriately, matching the recommendations in the background. This change should be made at the conditional statement in the `AuthCallback` method on line 104 in `backend/internal/handler/auth.go`. No external packages are required, and no existing functionality should be affected.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

---

Closes #183