### PR TITLE
refactor: remove unnecessary defineProps and defineEmits imports

### DIFF
--- a/frontend/src/components/AddToAlbumDialog.vue
+++ b/frontend/src/components/AddToAlbumDialog.vue
@@ -79,7 +79,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref, defineEmits, defineProps, watch } from 'vue'
+import { ref, watch } from 'vue'
 import type { AlbumItem } from '@/types'
 import { albumService } from '@/services'
 

--- a/frontend/src/components/CreateAlbumDialog.vue
+++ b/frontend/src/components/CreateAlbumDialog.vue
@@ -58,7 +58,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref, defineEmits, defineProps, watch } from 'vue'
+import { ref, watch } from 'vue'
 
 interface Props {
   isVisible: boolean


### PR DESCRIPTION
Remove defineProps and defineEmits from imports as they are compiler macros in Vue 3 and no longer need to be imported explicitly.